### PR TITLE
Fix order creation

### DIFF
--- a/src/controllers/auth_controller.ts
+++ b/src/controllers/auth_controller.ts
@@ -4,6 +4,7 @@ import { cache } from "../utils/cache";
 import dayjs from "dayjs";
 import { User } from "../models/User";
 import { Product } from "../models/Product";
+import { Order } from "../models/Order";
 import { Types } from "mongoose";
 import bcrypt from "bcryptjs";
 
@@ -245,13 +246,15 @@ export const createOrder = async (req: Request, res: Response) => {
 
         const total = Number((subtotal * 1.16).toFixed(2));
 
-        res.json({
-            userId,
-            status,
+        const newOrder = await Order.create({
+            createdBy: userId,
             products,
             subtotal,
-            total
+            total,
+            status
         });
+
+        res.status(201).json({ message: "Orden creada", order: newOrder });
     } catch (error) {
         console.error("Error al crear la orden:", error);
         res.status(500).json({ message: "Error al crear la orden", error });

--- a/src/models/Order.ts
+++ b/src/models/Order.ts
@@ -4,6 +4,11 @@ export interface IOrder {
   _id: Types.ObjectId;
   createdAt: Date;
   createdBy: Schema.Types.ObjectId;
+  products: {
+    product: Types.ObjectId;
+    quantity: number;
+    price: number;
+  }[];
   total: number;
   subtotal: number;
   status: string;
@@ -20,6 +25,23 @@ const orderSchema = new Schema<IOrder>({
     ref: "User",
     required: true
   },
+  products: [
+    {
+      product: {
+        type: Types.ObjectId,
+        ref: "Product",
+        required: true
+      },
+      quantity: {
+        type: Number,
+        required: true
+      },
+      price: {
+        type: Number,
+        required: true
+      }
+    }
+  ],
   total: {
     type: Number,
     required: true


### PR DESCRIPTION
## Summary
- persist created orders in MongoDB
- store product details in the `Order` model

## Testing
- `npm run build` *(fails: Cannot find type definition file for various packages)*

------
https://chatgpt.com/codex/tasks/task_e_68484604303c8325ac1ca1c0c9aab69e